### PR TITLE
Adding fix for php 7.4

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -454,6 +454,20 @@ class {$newClassName} {$extends}
     }
 
     /**
+     * Retrieves the name of the type.  Will adjust the method of retrieval based on PHP version.
+     *
+     * @return string
+     */
+    protected function getReturnTypeName($returnType)
+    {
+        if (version_compare(phpversion(), '7.1.0', '<')) 
+        {
+            return (string)$returnType;
+        }
+        return $returnType->getName();
+    }
+
+    /**
      * Creates the implementation of a single method
      *
      * @param ReflectionMethod $method
@@ -486,7 +500,7 @@ class {$newClassName} {$extends}
         if (method_exists($method, 'hasReturnType') && $method->hasReturnType())
         {
             $returnType = $method->getReturnType();
-            $returnTypeName = (string)$returnType;
+            $returnTypeName = $this->getReturnTypeName($returnType);
 
             if ($returnTypeName == 'self')
             {
@@ -616,7 +630,7 @@ class {$newClassName} {$extends}
                 $type = $parameter->getClass()->getName() . ' ';
             } elseif (method_exists($parameter, 'hasType') && $parameter->hasType())
             {
-                $type = $parameter->getType() . ' ';
+                $type = $this->getReturnTypeName($parameter->getType()) . ' ';
             }
 
             if (method_exists($parameter, 'hasType') && $parameter->hasType() && $parameter->allowsNull()) {

--- a/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
+++ b/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
@@ -54,6 +54,20 @@ class Phake_Stubber_Answers_SmartDefaultAnswer implements Phake_Stubber_IAnswer
 
     }
 
+    /**
+     * Retrieves the name of the type.  Will adjust the method of retrieval based on PHP version.
+     *
+     * @return string
+     */
+    protected function getReturnTypeName($returnType)
+    {
+        if (version_compare(phpversion(), '7.1.0', '<')) 
+        {
+            return (string)$returnType;
+        }
+        return $returnType->getName();
+    }
+
     public function getAnswerCallback($context, $method)
     {
         $class = new ReflectionClass($context);
@@ -63,7 +77,8 @@ class Phake_Stubber_Answers_SmartDefaultAnswer implements Phake_Stubber_IAnswer
 
         if (method_exists($method, 'hasReturnType') && $method->hasReturnType())
         {
-            switch ((string)$method->getReturnType())
+            $returnTypeName = $this->getReturnTypeName($method->getReturnType());
+            switch ($returnTypeName)
             {
                 case 'int':
                     $defaultAnswer = 0;
@@ -84,9 +99,9 @@ class Phake_Stubber_Answers_SmartDefaultAnswer implements Phake_Stubber_IAnswer
                     $defaultAnswer = function () {};
                     break;
                 default:
-                    if (class_exists((string)$method->getReturnType()))
+                    if (class_exists($returnTypeName))
                     {
-                        $defaultAnswer = Phake::mock((string)$method->getReturnType());
+                        $defaultAnswer = Phake::mock($returnTypeName);
                     }
                     break;
             }


### PR DESCRIPTION
This combines the fixes from the main repository for PHP 7.4 and tries to maintain the old version of retrieving the name to try and maintain support for 7.0.  Still need to test it against PHP 7.0.